### PR TITLE
Fix non-critical type inconsistency error in param_overview dataframe visualisation

### DIFF
--- a/src/owp_milp_optimization/pages/01_Optimierung.py
+++ b/src/owp_milp_optimization/pages/01_Optimierung.py
@@ -202,6 +202,7 @@ param_overview.rename(
         'net_dist': 'Wärmenetzlänge (km)'
         }, inplace=True
     )
+param_overview['Wert'] = param_overview['Wert'].astype(str)
 col_over.dataframe(param_overview, width='stretch')
 
 # %% MARK: Save Data


### PR DESCRIPTION
Fixes a Streamlit/PyArrow serialisation issue (that could be fixed automatically by Streamlit so it didn't disturb the user experience) in the parameter overview on the optimisation page by ensuring mixed-type values are converted to strings before rendering the dataframe. Before, the call to `col_over.dataframe(param_overview, width='stretch')` raised an error `pyarrow.lib.ArrowTypeError: ("Expected bytes, got a 'float' object", 'Conversion failed for column Wert with type object')` because different data types are present in the dataframe (string (the solver name) and float).