### PR TITLE
Fix rendering inconsistency where page layout is too narrow when subpages are accessed before home page is visited

### DIFF
--- a/src/owp_milp_optimization/pages/00_Energiesystem.py
+++ b/src/owp_milp_optimization/pages/00_Energiesystem.py
@@ -15,6 +15,10 @@ from pyomo.contrib.appsi.solvers import Highs
 from pyomo.opt import check_available_solvers
 from streamlit import session_state as ss
 
+st.set_page_config(
+    layout='wide',
+    page_icon=os.path.join(os.path.dirname(__file__), '..', 'img',  'page_icon_ZNES.png')
+    )
 
 # %% MARK: Read Input Data
 @st.cache_data

--- a/src/owp_milp_optimization/pages/01_Optimierung.py
+++ b/src/owp_milp_optimization/pages/01_Optimierung.py
@@ -9,6 +9,10 @@ from helpers import footer, load_icon_base64s
 from model import EnergySystem
 from streamlit import session_state as ss
 
+st.set_page_config(
+    layout='wide',
+    page_icon=os.path.join(os.path.dirname(__file__), '..', 'img',  'page_icon_ZNES.png')
+    )
 
 @st.dialog('Energiesystem lokal speichern')
 def download_energy_system():

--- a/src/owp_milp_optimization/pages/02_Simulationsergebnisse.py
+++ b/src/owp_milp_optimization/pages/02_Simulationsergebnisse.py
@@ -14,6 +14,10 @@ from helpers import footer, format_sep, load_icon_base64s
 from reporting import generate_html_report
 from streamlit import session_state as ss
 
+st.set_page_config(
+    layout='wide',
+    page_icon=os.path.join(os.path.dirname(__file__), '..', 'img',  'page_icon_ZNES.png')
+    )
 
 @st.dialog('Ergebnisse lokal speichern')
 def save_results():


### PR DESCRIPTION
Set the page layout to wide (and icon to ZNES) for all subpages using `st.set_page_config()` on the subpages. Without this, the app is displayed in `centered` mode by default if a subpage is accessed before the home page is accessed, which makes the content very narrow.